### PR TITLE
Correct classname in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,7 @@
     <workbench>
       <icon>Resources/FrotISTR.svg</icon>
       <subdirectory>./</subdirectory>
-      <classname>FemToolsFISTR</classname>
+      <classname>FrontISTR</classname>
       <tag>FEM</tag>
       <tag>solver</tag>
     </workbench>


### PR DESCRIPTION
The entry class in InitGui.py is called `FrontISTR`.