### PR TITLE
Correct icon name typo

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -15,7 +15,7 @@
 
   <content>
     <workbench>
-      <icon>Resources/FrotISTR.svg</icon>
+      <icon>Resources/FrontISTR.svg</icon>
       <subdirectory>./</subdirectory>
       <classname>FrontISTR</classname>
       <tag>FEM</tag>


### PR DESCRIPTION
Another small fix to package.xml -- there is a typo in one of the icon specifications.