### PR TITLE
FIXED: compatibility with FreeCAD 0.20

### DIFF
--- a/femsolver_FrontISTR/writer.py
+++ b/femsolver_FrontISTR/writer.py
@@ -551,7 +551,7 @@ class FemInputWriterfistr(writerbase.FemInputWriter):
     # ********************************************************************************************
     # constraints sectionprint
     def write_surfaces_constraints_sectionprint(self, f):
-        if not self.sectionprint_objects:
+        if not self.member.cons_sectionprint:
             return
         # write for all analysis types
 
@@ -566,7 +566,7 @@ class FemInputWriterfistr(writerbase.FemInputWriter):
     def write_surfacefaces_constraints_sectionprint(self, f):
         # get surface nodes and write them to file
         obj = 0
-        for femobj in self.sectionprint_objects:
+        for femobj in self.member.cons_sectionprint:
             # femobj --> dict, FreeCAD document object is femobj["Object"]
             sectionprint_obj = femobj["Object"]
             f.write("** " + sectionprint_obj.Label + "\n")

--- a/fistrtools.py
+++ b/fistrtools.py
@@ -257,8 +257,8 @@ class FemToolsFISTR(QtCore.QRunnable, QtCore.QObject):
                 "Working directory \'{}\' doesn't exist."
                 .format(self.working_dir)
             )
-        from femtools.checksanalysis import check_analysismember
-        message += check_analysismember(
+        from femtools.checksanalysis import check_member_for_solver_calculix
+        message += check_member_for_solver_calculix(
             self.analysis,
             self.solver,
             self.mesh,


### PR DESCRIPTION
Due to a couple changes to the FEM writer API (see this commit https://github.com/FreeCAD/FreeCAD/commit/d0dbdf8bf364e05b2b41258449288207697d1d4e), this plugin did not work with FreeCAD 0.20 or Realthunder's fork.

After these modifications, it seems to work again. At least the static analysis input file now writes without error.